### PR TITLE
Update afvalwijzer.html

### DIFF
--- a/afvalwijzer-plugin/templates/afvalwijzer.html
+++ b/afvalwijzer-plugin/templates/afvalwijzer.html
@@ -1,6 +1,6 @@
 <link href="static/css/afvalwijzer.css" rel="stylesheet" type="text/css"/>
 {% for k, v in blockArray[count]["afvalwijzer"].iteritems() %}
-<div class="col-md-7 col-sm-6 col-xs-12">
+<div class="row">
   <div class="x_panel">
   <div class="x_title">
       <h2 id="title_{{count}}">Afvalwijzer - {{ v[1] }} {{ v[2] }}</h2>


### PR DESCRIPTION
Changed panel to full width. All text and First Date fits better.

Maybe when no First Date is available, only create one column and the use  'col-md-7 col-sm-6 col-xs-12' instead of 'row'